### PR TITLE
Redesign portfolio around backend engineering

### DIFF
--- a/frontend/app/about/components/AboutContent.tsx
+++ b/frontend/app/about/components/AboutContent.tsx
@@ -174,7 +174,7 @@ export function AboutContent({
   ];
 
   return (
-    <main className="container py-12">
+    <div className="container mx-auto px-[15px] py-12">
       <div className="mx-auto max-w-5xl">
         <div className="mb-12 flex flex-col gap-4">
           <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -408,6 +408,6 @@ export function AboutContent({
           </div>
         </section>
       </div>
-    </main>
+    </div>
   );
 }

--- a/frontend/app/blog/components/BlogContent.tsx
+++ b/frontend/app/blog/components/BlogContent.tsx
@@ -41,7 +41,7 @@ export function BlogContent({
   fallbackReason = null,
 }: BlogContentProps) {
   return (
-    <div className="container py-12">
+    <div className="container mx-auto px-[15px] py-12">
       <div className="max-w-4xl mx-auto">
         <div className="flex flex-col gap-4 mb-12">
           <h1 className="text-3xl font-bold">{copy.title}</h1>

--- a/frontend/app/contact/components/ContactContent.tsx
+++ b/frontend/app/contact/components/ContactContent.tsx
@@ -66,7 +66,7 @@ export function ContactContent({ copy }: { copy: ContactCopy }) {
   };
 
   return (
-    <div className="container py-12">
+    <div className="container mx-auto px-[15px] py-12">
       <div className="max-w-4xl mx-auto">
         <div className="flex flex-col gap-4 mb-12">
           <h1 className="text-3xl font-bold">{copy.title}</h1>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,9 @@
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
+    --signal: 143 57% 51%;
+    --protocol: 219 60% 58%;
+    --steel: 211 9% 53%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -68,6 +71,9 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+    --signal: 143 57% 51%;
+    --protocol: 219 68% 66%;
+    --steel: 211 10% 67%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -93,6 +99,17 @@
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    letter-spacing: 0;
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    background: hsl(var(--signal) / 0.22);
+  }
+
+  :focus-visible {
+    outline: 2px solid hsl(var(--protocol));
+    outline-offset: 3px;
   }
 
   .skip-link {
@@ -112,5 +129,27 @@
 
   .skip-link:focus {
     transform: translateY(0);
+  }
+}
+
+@layer components {
+  .portfolio-kicker {
+    @apply font-mono text-xs font-medium uppercase text-muted-foreground;
+    letter-spacing: 0.12em;
+  }
+
+  .portfolio-rule {
+    @apply border-border/80;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 import Script from 'next/script';
@@ -15,7 +15,19 @@ import {
   resolveLocale,
 } from '@/lib/seo';
 
-const inter = Inter({ subsets: ["latin"] });
+const plexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-plex-sans",
+  display: "swap",
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-plex-mono",
+  display: "swap",
+});
 
 // The proxy stamps x-app-locale from the URL (/pt-BR/*) or the NEXT_LOCALE
 // cookie, so crawlers without cookies still get pt-BR on /pt-BR routes.
@@ -62,6 +74,8 @@ export default async function RootLayout({
   // Locale resolved from the proxy header (URL-aware) with cookie fallback
   const locale = await resolveRequestLocale();
   const skipLinkLabel = locale === 'pt-BR' ? 'Pular para o conteúdo principal' : 'Skip to main content';
+  const machinePortfolioHref = '/portfolio.md?lang=' + (locale === 'pt-BR' ? 'pt-BR' : 'en');
+  const llmsHref = '/llms.txt?lang=' + (locale === 'pt-BR' ? 'pt-BR' : 'en');
 
   return (
     <html lang={locale} suppressHydrationWarning>
@@ -76,8 +90,10 @@ export default async function RootLayout({
         ></meta>
         <JsonLd data={buildPersonJsonLd()} />
         <JsonLd data={buildWebSiteJsonLd()} />
+        <link rel="alternate" type="text/markdown" href={machinePortfolioHref} title="Machine-readable portfolio" />
+        <link rel="alternate" type="text/plain" href={llmsHref} title="LLM content index" />
       </head>
-      <body className={`${inter.className} flex flex-col min-h-screen`}>
+      <body className={plexSans.variable + " " + plexMono.variable + " flex min-h-screen flex-col font-sans"}>
         <a href="#main-content" className="skip-link">
           {skipLinkLabel}
         </a>

--- a/frontend/app/llms.txt/route.ts
+++ b/frontend/app/llms.txt/route.ts
@@ -1,0 +1,30 @@
+import aboutEn from '@/public/locales/en/about.json';
+import aboutPtBr from '@/public/locales/pt-BR/about.json';
+import { buildLlmsText } from '@/lib/portfolio-machine-content';
+import { getSiteUrl } from '@/lib/seo';
+
+function resolveRequestLocale(request: Request) {
+  const url = new URL(request.url);
+  if (url.searchParams.get('lang') === 'pt-BR') return 'pt-BR';
+
+  return request.headers.get('accept-language')?.toLowerCase().startsWith('pt')
+    ? 'pt-BR'
+    : 'en';
+}
+
+export function GET(request: Request) {
+  const locale = resolveRequestLocale(request);
+  const content = buildLlmsText({
+    locale,
+    siteUrl: getSiteUrl(),
+    about: locale === 'pt-BR' ? aboutPtBr.about : aboutEn.about,
+  });
+
+  return new Response(content, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,109 +1,217 @@
 'use client';
 
-import Link from "next/link";
-import Image from "next/image";
-import { Button } from "@/components/ui/button";
-import { ArrowRight, Code, Leaf, Monitor } from "lucide-react";
-import { useTranslation } from "react-i18next";
-import { DecoderText } from '@/components/decoderText/decoderText';
-import { useInView } from 'react-intersection-observer';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ArrowRight, ArrowUpRight, Check, Mail, ServerCog } from 'lucide-react';
+import { FaGithub } from 'react-icons/fa';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { projects, type ProjectLocale } from '@/data/projects';
+import { isPtBrPathname, withPtBrPrefix } from '@/lib/locale-paths';
+
+const processKeys = ['contract', 'security', 'quality', 'delivery'] as const;
 
 export default function Home() {
-  const { t } = useTranslation('home');
-  const title = t('home.title');
-  const subtitle = t('home.subtitle');
+  const { t, i18n } = useTranslation('home');
+  const pathname = usePathname();
+  const locale: ProjectLocale = i18n.resolvedLanguage === 'pt-BR' ? 'pt-BR' : 'en';
+  const localizePath = (href: string) => (isPtBrPathname(pathname) ? withPtBrPrefix(href) : href);
+  const featuredProjects = projects
+    .filter((project) => project.featured)
+    .sort((a, b) => (a.featuredOrder ?? 0) - (b.featuredOrder ?? 0));
 
-  const { ref: subtitleRef, inView: subtitleInView } = useInView({ triggerOnce: true, threshold: .9});
+  const traceItems = [
+    { label: t('home.trace.request'), value: t('home.trace.request_value') },
+    { label: t('home.trace.security'), value: t('home.trace.security_value') },
+    { label: t('home.trace.persistence'), value: t('home.trace.persistence_value') },
+    { label: t('home.trace.response'), value: t('home.trace.response_value') },
+  ];
 
   return (
-    <>
-      <div className="flex-1">
-        <section className="container flex flex-col items-center justify-center gap-4 py-20 md:py-32">
-          <div className="flex flex-col md:flex-row items-center gap-10 md:gap-16 text-center md:text-left">
-            <div className="flex-shrink-0">
-              <div className="relative w-40 h-40 md:w-52 md:h-52 rounded-full overflow-hidden border-4 border-primary ring-4 ring-primary/20 shadow-xl">
-                <Image
-                  src="/images/home/profilelinkedin.jpeg"
-                  alt="Mateus R Campos"
-                  fill
-                  sizes="(max-width: 768px) 160px, 208px"
-                  className="object-cover"
-                  priority
-                  fetchPriority="high"
-                  loading="eager"
-                />
-              </div>
-            </div>
-            <div className="flex flex-col items-center md:items-start gap-4">
-            <h1 className="text-3xl font-bold sm:text-4xl md:text-5xl lg:text-6xl">
-              <DecoderText text={title} delay={600} />
-            </h1>
-            <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
-              {t('home.pTitle')}
+    <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+      <section className="portfolio-rule relative overflow-hidden border-x border-b bg-background/95">
+        <Image
+          src="/images/home/profilelinkedin.jpeg"
+          alt=""
+          fill
+          sizes="(max-width: 768px) 100vw, 1280px"
+          className="pointer-events-none object-cover object-[72%_38%] opacity-[0.11] grayscale dark:opacity-[0.16]"
+          priority
+          aria-hidden="true"
+        />
+        <div className="pointer-events-none absolute inset-y-0 right-[12%] hidden w-px bg-signal/30 lg:block" />
+
+        <div className="relative flex min-h-[660px] flex-col justify-between px-5 py-8 sm:px-8 md:min-h-[620px] md:px-12 md:py-10 lg:px-16">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="portfolio-kicker text-foreground">{t('home.eyebrow')}</p>
+            <p className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+              <span className="h-2 w-2 rounded-full bg-signal" aria-hidden="true" />
+              {t('home.availability')}
             </p>
-            <div className="flex gap-4">
-              <Button variant="outline" asChild>
-                <Link href="/contact">{t('home.contact_button')}</Link>
+          </div>
+
+          <div className="max-w-4xl py-14 md:py-16">
+            <h1 className="max-w-4xl text-4xl font-semibold leading-[1.04] sm:text-5xl md:text-6xl">
+              {t('home.title')}
+            </h1>
+            <p className="mt-7 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
+              {t('home.description')}
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Button size="lg" asChild>
+                <Link href={localizePath('/projects')}>
+                  {t('home.projects_button')}
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
               </Button>
-              <Button asChild>
-                <Link href="/projects">{t('home.projects_button')}<ArrowRight className="ml-2 h-4 w-4" />
+              <Button size="lg" variant="outline" asChild>
+                <a
+                  href="https://github.com/mateusribeirocampos"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <FaGithub className="mr-2 h-4 w-4" />
+                  {t('home.github_button')}
+                </a>
+              </Button>
+              <Button size="lg" variant="ghost" asChild>
+                <Link href={localizePath('/contact')}>
+                  <Mail className="mr-2 h-4 w-4" />
+                  {t('home.contact_button')}
                 </Link>
               </Button>
             </div>
+
+            <div className="mt-9 flex flex-col gap-2 border-l-2 border-signal pl-4">
+              <span className="portfolio-kicker">{t('home.stack_label')}</span>
+              <span className="font-mono text-sm text-foreground">{t('home.stack')}</span>
             </div>
           </div>
-          {/*<div className="w-full max-w-3xl mt-8">
-            <Animation />
-          </div>*/}
-        </section>
-        <section className="py-24 relative overflow-hidden bg-gradient-to-br from-background via-primary/5 to-background">
-          <div className="absolute inset-0 w-full h-full">
-            <div className="absolute right-0 top-0 w-96 h-96 bg-primary/5 rounded-full blur-3xl -a-10"></div>
-            <div className="absolute left-0 bottom-0 w-96 h-96 bg-primary/5 rounded-full blur-3xl -a-10"></div>
-          </div>
 
-          <div className="container px-4">
-            <div className="text-center mb-20 relative">
-              <div className="items-center rounded-md py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground mb-4">
-                <h2 ref={subtitleRef} className="inline-flex text-4xl md:text-5xl font-bold mb-6">
-                  <DecoderText text={subtitle} start={subtitleInView} delay={500} />
-                </h2>
-                <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-                  {t('home.pSubtitle')}
+          <div className="portfolio-rule grid border-t sm:grid-cols-2 lg:grid-cols-4">
+            {traceItems.map((item, index) => (
+              <div
+                key={item.label}
+                className="portfolio-rule min-w-0 border-b py-4 sm:px-4 sm:odd:border-r lg:border-b-0 lg:border-r lg:first:pl-0 lg:last:border-r-0 lg:last:pr-0"
+              >
+                <p className="font-mono text-[11px] text-muted-foreground">
+                  {String(index + 1).padStart(2, '0')} / {item.label}
                 </p>
+                <p className="mt-1 truncate font-mono text-sm font-medium">{item.value}</p>
               </div>
-            </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 md:py-24">
+        <div className="grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:gap-16">
+          <div className="lg:sticky lg:top-28 lg:self-start">
+            <p className="portfolio-kicker">{t('home.evidence.eyebrow')}</p>
+            <h2 className="mt-4 max-w-lg text-3xl font-semibold leading-tight md:text-4xl">
+              {t('home.evidence.title')}
+            </h2>
+            <p className="mt-5 max-w-md leading-7 text-muted-foreground">
+              {t('home.evidence.description')}
+            </p>
           </div>
 
-          <div className="grid gap-6 md:grid-cols-3">
-            <div className="flex flex-col items-center text-center p-6 bg-card rounded-lg border border-primary">
-              <Code className="h-12 w-12 mb-4 text-primary" />
-              <h3 className="text-xl font-semibold mb-2">
-                {t("home.TitleCard1")}
-              </h3>
-              <p className="text-muted-foreground">
-                {t("home.pCard1")}
-              </p>
-            </div>
-            <div className="flex flex-col items-center text-center p-6 bg-card rounded-lg border border-primary">
-              <Monitor className="h-12 w-12 mb-4 text-primary" />
-              <h3 className="text-xl font-semibold mb-2">{t("home.TitleCard2")}</h3>
-              <p className="text-muted-foreground">
-                {t("home.pCard2")}
-              </p>
-            </div>
-            <div className="flex flex-col items-center text-center p-6 bg-card rounded-lg border border-primary">
-              <Leaf className="h-12 w-12 mb-4 text-primary" />
-              <h3 className="text-xl font-semibold mb-2">
-                {t("home.TitleCard3")}
-              </h3>
-              <p className="text-muted-foreground">
-                {t("home.pCard3")}
-              </p>
-            </div>
+          <div className="portfolio-rule border-t">
+            {featuredProjects.map((project, index) => (
+              <article
+                key={project.slug}
+                className="portfolio-rule group grid gap-5 border-b py-8 sm:grid-cols-[72px_1fr] sm:py-10"
+              >
+                <div className="font-mono text-sm text-muted-foreground">
+                  {String(index + 1).padStart(2, '0')}
+                </div>
+                <div>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="portfolio-kicker text-protocol">{project.kind[locale]}</p>
+                      <h3 className="mt-2 text-2xl font-semibold">{project.title}</h3>
+                    </div>
+                    <span className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+                      <Check className="h-3.5 w-3.5 text-signal" />
+                      {project.status[locale]}
+                    </span>
+                  </div>
+                  <p className="mt-4 max-w-2xl leading-7 text-muted-foreground">
+                    {project.description[locale]}
+                  </p>
+                  <div className="mt-5 flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs text-muted-foreground">
+                    {project.tags.slice(0, 5).map((tag) => (
+                      <span key={tag}>{tag}</span>
+                    ))}
+                  </div>
+                  <Link
+                    href={localizePath('/projects') + '#' + project.slug}
+                    className="mt-6 inline-flex items-center text-sm font-medium underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+                  >
+                    {t('home.evidence.project_link')}
+                    <ArrowUpRight className="ml-2 h-4 w-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                  </Link>
+                </div>
+              </article>
+            ))}
           </div>
-        </section>
-      </div>
-    </>
+        </div>
+      </section>
+
+      <section className="portfolio-rule border-y py-20 md:py-24">
+        <div className="grid gap-12 lg:grid-cols-[0.72fr_1.28fr] lg:gap-16">
+          <div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md border bg-background">
+              <ServerCog className="h-5 w-5 text-protocol" />
+            </div>
+            <p className="portfolio-kicker mt-6">{t('home.process.eyebrow')}</p>
+            <h2 className="mt-4 text-3xl font-semibold leading-tight md:text-4xl">
+              {t('home.process.title')}
+            </h2>
+            <p className="mt-5 max-w-md leading-7 text-muted-foreground">
+              {t('home.process.description')}
+            </p>
+          </div>
+
+          <ol className="portfolio-rule border-t">
+            {processKeys.map((key, index) => (
+              <li
+                key={key}
+                className="portfolio-rule grid gap-4 border-b py-6 sm:grid-cols-[72px_180px_1fr] sm:items-start"
+              >
+                <span className="font-mono text-sm text-signal">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <h3 className="font-semibold">{t('home.process.steps.' + key + '.title')}</h3>
+                <p className="text-sm leading-6 text-muted-foreground">
+                  {t('home.process.steps.' + key + '.description')}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="grid gap-8 py-20 md:grid-cols-[1fr_auto] md:items-end md:py-24">
+        <div className="max-w-3xl">
+          <p className="portfolio-kicker">{t('home.closing.eyebrow')}</p>
+          <h2 className="mt-4 text-3xl font-semibold leading-tight md:text-4xl">
+            {t('home.closing.title')}
+          </h2>
+          <p className="mt-5 max-w-2xl leading-7 text-muted-foreground">
+            {t('home.closing.description')}
+          </p>
+        </div>
+        <Button size="lg" asChild>
+          <Link href={localizePath('/contact')}>
+            {t('home.contact_button')}
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </section>
+    </div>
   );
 }

--- a/frontend/app/portfolio.md/route.ts
+++ b/frontend/app/portfolio.md/route.ts
@@ -1,0 +1,35 @@
+import aboutEn from '@/public/locales/en/about.json';
+import aboutPtBr from '@/public/locales/pt-BR/about.json';
+import { projects } from '@/data/projects';
+import { buildPortfolioMarkdown } from '@/lib/portfolio-machine-content';
+import { getSiteUrl } from '@/lib/seo';
+
+function resolveRequestLocale(request: Request) {
+  const url = new URL(request.url);
+  if (url.searchParams.get('lang') === 'pt-BR') return 'pt-BR';
+
+  return request.headers.get('accept-language')?.toLowerCase().startsWith('pt')
+    ? 'pt-BR'
+    : 'en';
+}
+
+export function GET(request: Request) {
+  const locale = resolveRequestLocale(request);
+  const url = new URL(request.url);
+  const markdown = buildPortfolioMarkdown({
+    locale,
+    siteUrl: getSiteUrl(),
+    about: locale === 'pt-BR' ? aboutPtBr.about : aboutEn.about,
+    projects,
+  });
+  const disposition = url.searchParams.get('download') === '1' ? 'attachment' : 'inline';
+
+  return new Response(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Content-Disposition': disposition + '; filename="mateus-r-campos-portfolio-' + locale + '.md"',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+}

--- a/frontend/app/projects/components/ProjectsContent.tsx
+++ b/frontend/app/projects/components/ProjectsContent.tsx
@@ -1,107 +1,288 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ExternalLink } from 'lucide-react';
-import { FaGithub } from "react-icons/fa";
-import Link from 'next/link';
-import Image from 'next/image';
-import { projects, type ProjectLocale } from '@/data/projects';
 import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight, Check, ExternalLink, ServerCog } from 'lucide-react';
+import { FaGithub } from 'react-icons/fa';
+
+import { Button } from '@/components/ui/button';
+import { projects, type Project, type ProjectLocale } from '@/data/projects';
+import { cn } from '@/lib/utils';
 
 interface ProjectsCopy {
+  eyebrow: string;
   title: string;
   pTitle: string;
+  featuredTitle: string;
+  featuredDescription: string;
+  architectureLabel: string;
+  evidenceLabel: string;
+  stackLabel: string;
+  otherTitle: string;
+  otherDescription: string;
+  sourceCode: string;
   liveDemo: string;
 }
 
-export function ProjectsContent({ copy, locale }: { copy: ProjectsCopy; locale: ProjectLocale }) {
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+function ProjectImage({
+  project,
+  priority = false,
+}: {
+  project: Project;
+  priority?: boolean;
+}) {
   const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
+  const primaryFailed = imageErrors[project.image];
+  const secondaryFailed = project.secondImage ? imageErrors[project.secondImage] : true;
+  const hasSecondaryImage = Boolean(project.secondImage && !secondaryFailed);
 
-  const handleImageError = (src: string) => {
-    setImageErrors(prev => ({ ...prev, [src]: true }));
-  };
+  if (primaryFailed) {
+    return (
+      <div className="flex h-full min-h-48 items-center justify-center bg-muted">
+        <ServerCog className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+      </div>
+    );
+  }
 
   return (
-    <div className="container py-12">
-      <div className="flex flex-col gap-4 mb-12">
-        <h1 className="text-3xl font-bold">{copy.title}</h1>
-        <p className="text-muted-foreground">{copy.pTitle}</p>
-      </div>
-      
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {projects.map((project, index) => (
-          <Card 
-            key={index}
-            onMouseEnter={() => setHoveredIndex(index)}
-            onMouseLeave={() => setHoveredIndex(null)}
-          >
-            <CardHeader>
-              <CardTitle>{project.title}</CardTitle>
-              <CardDescription>{project.description[locale] ?? project.description.en}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="relative w-full h-48 mb-4">
-                {!imageErrors[project.image] && (
-                  <Image
-                    src={project.image}
-                    alt={project.title}
-                    width={500}
-                    height={300}
-                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                    onError={() => handleImageError(project.image)}
-                    className={`w-full h-full object-cover rounded-md transition-opacity duration-300 ${
-                      hoveredIndex === index && project.secondImage ? 'opacity-0' : 'opacity-100'
-                    }`}
-                  />
-                )}
-                {project.secondImage && !imageErrors[project.secondImage] && (
-                  <Image
-                    src={project.secondImage}
-                    alt={`${project.title} - Second view`}
-                    width={500}
-                    height={300}
-                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                    onError={() => project.secondImage && handleImageError(project.secondImage)}
-                    className={`absolute top-0 left-0 w-full h-full object-cover rounded-md transition-opacity duration-300 ${
-                      hoveredIndex === index ? 'opacity-100' : 'opacity-0'
-                    }`}
-                  />
-                )}
+    <div className="group relative h-full min-h-48 overflow-hidden bg-muted">
+      <Image
+        src={project.image}
+        alt={project.title}
+        fill
+        sizes="(max-width: 1024px) 100vw, 46vw"
+        onError={() => setImageErrors((current) => ({ ...current, [project.image]: true }))}
+        className={cn(
+          'object-cover transition-opacity duration-300',
+          hasSecondaryImage && 'group-hover:opacity-0',
+        )}
+        priority={priority}
+      />
+      {project.secondImage && !secondaryFailed ? (
+        <Image
+          src={project.secondImage}
+          alt=""
+          fill
+          sizes="(max-width: 1024px) 100vw, 46vw"
+          onError={() =>
+            setImageErrors((current) => ({
+              ...current,
+              [project.secondImage as string]: true,
+            }))
+          }
+          className="object-cover opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+          aria-hidden="true"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function ProjectsContent({ copy, locale }: { copy: ProjectsCopy; locale: ProjectLocale }) {
+  const featuredProjects = projects
+    .filter((project) => project.featured)
+    .sort((a, b) => (a.featuredOrder ?? 0) - (b.featuredOrder ?? 0));
+  const otherProjects = projects.filter((project) => !project.featured);
+
+  return (
+    <div className="container mx-auto px-[15px] py-14 md:py-20">
+      <header className="mx-auto max-w-5xl">
+        <p className="portfolio-kicker">{copy.eyebrow}</p>
+        <h1 className="mt-4 max-w-4xl text-4xl font-semibold leading-[1.06] sm:text-5xl md:text-6xl">
+          {copy.title}
+        </h1>
+        <p className="mt-6 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
+          {copy.pTitle}
+        </p>
+      </header>
+
+      <section className="mx-auto mt-20 max-w-5xl">
+        <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-end">
+          <div>
+            <h2 className="text-2xl font-semibold md:text-3xl">{copy.featuredTitle}</h2>
+            <p className="mt-3 max-w-2xl text-muted-foreground">{copy.featuredDescription}</p>
+          </div>
+          <span className="font-mono text-xs text-muted-foreground">
+            {String(featuredProjects.length).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
+          </span>
+        </div>
+
+        <div className="portfolio-rule mt-8 border-t">
+          {featuredProjects.map((project, projectIndex) => (
+            <article
+              id={project.slug}
+              key={project.slug}
+              className="portfolio-rule scroll-mt-24 border-b py-10 md:py-14"
+            >
+              <div className="grid gap-8 lg:grid-cols-[0.84fr_1.16fr] lg:gap-12">
+                <div className="space-y-6">
+                  <div className="portfolio-rule relative aspect-[4/3] overflow-hidden rounded-md border">
+                    <ProjectImage project={project} priority={projectIndex === 0} />
+                  </div>
+
+                  <div>
+                    <p className="portfolio-kicker">{copy.stackLabel}</p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {project.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-md border bg-secondary px-2 py-1 font-mono text-xs text-secondary-foreground"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="portfolio-kicker text-protocol">
+                      {String(projectIndex + 1).padStart(2, '0')} / {project.kind[locale]}
+                    </p>
+                    <span className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+                      <Check className="h-3.5 w-3.5 text-signal" />
+                      {project.status[locale]}
+                    </span>
+                  </div>
+
+                  <h3 className="mt-4 text-3xl font-semibold">{project.title}</h3>
+                  <p className="mt-5 leading-7 text-muted-foreground">
+                    {project.description[locale]}
+                  </p>
+
+                  {project.architecture ? (
+                    <div className="mt-8">
+                      <p className="portfolio-kicker">{copy.architectureLabel}</p>
+                      <div className="mt-4 flex flex-wrap items-center gap-2">
+                        {project.architecture.map((stage, stageIndex) => (
+                          <div key={stage} className="flex items-center gap-2">
+                            <span className="rounded-md border bg-background px-2.5 py-1.5 font-mono text-xs">
+                              {stage}
+                            </span>
+                            {stageIndex < project.architecture!.length - 1 ? (
+                              <ArrowRight className="h-3.5 w-3.5 text-steel" aria-hidden="true" />
+                            ) : null}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {project.evidence ? (
+                    <div className="mt-8">
+                      <p className="portfolio-kicker">{copy.evidenceLabel}</p>
+                      <dl className="portfolio-rule mt-4 border-t">
+                        {project.evidence.map((item) => (
+                          <div
+                            key={item.label[locale]}
+                            className="portfolio-rule grid gap-2 border-b py-4 sm:grid-cols-[120px_1fr]"
+                          >
+                            <dt className="font-mono text-xs font-medium text-signal">
+                              {item.label[locale]}
+                            </dt>
+                            <dd className="text-sm leading-6 text-muted-foreground">
+                              {item.value[locale]}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </div>
+                  ) : null}
+
+                  <div className="mt-8 flex flex-wrap gap-3">
+                    {project.github ? (
+                      <Button variant="outline" asChild>
+                        <Link href={project.github} target="_blank" rel="noopener noreferrer">
+                          <FaGithub className="mr-2 h-4 w-4" />
+                          {copy.sourceCode}
+                        </Link>
+                      </Button>
+                    ) : null}
+                    {project.demo ? (
+                      <Button asChild>
+                        <Link href={project.demo} target="_blank" rel="noopener noreferrer">
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          {copy.liveDemo}
+                        </Link>
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {project.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="px-2 py-1 bg-secondary text-secondary-foreground rounded-md text-sm"
-                  >
-                    {tag}
-                  </span>
-                ))}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto mt-20 max-w-5xl">
+        <div>
+          <h2 className="text-2xl font-semibold md:text-3xl">{copy.otherTitle}</h2>
+          <p className="mt-3 max-w-2xl text-muted-foreground">{copy.otherDescription}</p>
+        </div>
+
+        <div className="mt-8 grid gap-5 md:grid-cols-3">
+          {otherProjects.map((project) => (
+            <article
+              key={project.slug}
+              className="portfolio-rule flex min-h-full flex-col overflow-hidden rounded-md border bg-card"
+            >
+              <div className="aspect-video overflow-hidden border-b">
+                <ProjectImage project={project} />
               </div>
-            </CardContent>
-            <CardFooter className="flex gap-2">
-              {project.github && (
-                <Button variant="outline" size="sm" asChild>
-                  <Link href={project.github} target="_blank" rel="noopener noreferrer">
-                    <FaGithub className="mr-2 h-4 w-4" />
-                    GitHub
-                  </Link>
-                </Button>
-              )}
-              {project.demo && (
-                <Button size="sm" asChild>
-                  <Link href={project.demo} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="mr-2 h-4 w-4" />
-                    {copy.liveDemo}
-                  </Link>
-                </Button>
-              )}
-            </CardFooter>
-          </Card>
-        ))}
-      </div>
+              <div className="flex flex-1 flex-col p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="portfolio-kicker text-protocol">{project.kind[locale]}</p>
+                  <span className="h-2 w-2 shrink-0 rounded-full bg-signal" aria-hidden="true" />
+                </div>
+                <h3 className="mt-3 text-xl font-semibold">{project.title}</h3>
+                <p className="mt-3 flex-1 text-sm leading-6 text-muted-foreground">
+                  {project.description[locale]}
+                </p>
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {project.tags.slice(0, 4).map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-md border bg-secondary px-2 py-1 font-mono text-[11px]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-5 flex gap-2">
+                  {project.github ? (
+                    <Button variant="outline" size="icon" asChild>
+                      <Link
+                        href={project.github}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={copy.sourceCode + ': ' + project.title}
+                        title={copy.sourceCode}
+                      >
+                        <FaGithub className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                  ) : null}
+                  {project.demo ? (
+                    <Button variant="outline" size="icon" asChild>
+                      <Link
+                        href={project.demo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={copy.liveDemo + ': ' + project.title}
+                        title={copy.liveDemo}
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/components/layout-client.tsx
+++ b/frontend/components/layout-client.tsx
@@ -7,6 +7,7 @@ import { Footer } from '@/components/footer';
 import { Providers } from '@/providers';
 import MatrixRain from './matrixRain';
 import { PageTracker } from './page-tracker';
+import { MachineReadablePortfolio } from './machine-readable-portfolio';
 
 function ScrollToTop() {
   const pathname = usePathname();
@@ -28,10 +29,11 @@ export function LayoutClient({
       <ScrollToTop />
       <PageTracker />
       <MatrixRain />
+      <MachineReadablePortfolio lang={lang} />
       <div className="flex-1 flex flex-col">
         <Navigation />
         <main id="main-content" className="flex-1 flex flex-col" tabIndex={-1}>
-          <div className="container flex-1 mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex-1 w-full">
             {children}
           </div>
         </main>

--- a/frontend/components/machine-readable-portfolio.tsx
+++ b/frontend/components/machine-readable-portfolio.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { Bot, Check, Copy, Download, UserRound, X } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { projects, type ProjectLocale } from '@/data/projects';
+import { buildPortfolioMarkdown } from '@/lib/portfolio-machine-content';
+import aboutEn from '@/public/locales/en/about.json';
+import aboutPtBr from '@/public/locales/pt-BR/about.json';
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://portfolio-mateusribeirocampos.vercel.app';
+
+const uiCopy = {
+  en: {
+    ready: 'LLM ready',
+    rendered: 'Reading',
+    source: 'Markdown',
+    copy: 'Copy Markdown',
+    copied: 'Copied',
+    download: 'Download Markdown',
+    close: 'Close LLM view',
+    human: 'Human view',
+    machine: 'LLM view',
+    profile: 'Profile',
+    focus: 'How I work',
+    experience: 'Experience',
+    projects: 'Projects',
+    stack: 'Core capabilities',
+    contact: 'Contact',
+  },
+  'pt-BR': {
+    ready: 'Pronto para LLM',
+    rendered: 'Leitura',
+    source: 'Markdown',
+    copy: 'Copiar Markdown',
+    copied: 'Copiado',
+    download: 'Baixar Markdown',
+    close: 'Fechar leitura para LLM',
+    human: 'Visualização humana',
+    machine: 'Visualização para LLM',
+    profile: 'Perfil',
+    focus: 'Como atuo',
+    experience: 'Experiência',
+    projects: 'Projetos',
+    stack: 'Competências principais',
+    contact: 'Contato',
+  },
+};
+
+function MachineDocument({ locale }: { locale: ProjectLocale }) {
+  const copy = uiCopy[locale];
+  const about = locale === 'pt-BR' ? aboutPtBr.about : aboutEn.about;
+  const skillGroups = Object.values(about.skills).filter(
+    (value): value is { title: string; description: string } =>
+      Boolean(value && typeof value === 'object' && 'title' in value),
+  );
+  const orderedProjects = [...projects].sort(
+    (a, b) => (a.featuredOrder ?? 99) - (b.featuredOrder ?? 99),
+  );
+
+  return (
+    <article className="mx-auto max-w-4xl px-[15px] py-12 sm:py-16">
+      <header className="portfolio-rule border-b pb-8">
+        <p className="portfolio-kicker text-protocol">portfolio.md / {locale}</p>
+        <h1 className="mt-4 text-3xl font-semibold leading-tight sm:text-4xl">
+          Mateus R. Campos
+          <span className="block text-signal">
+            {locale === 'pt-BR' ? 'Desenvolvedor Backend' : 'Backend Developer'}
+          </span>
+        </h1>
+        <blockquote className="mt-7 border-l-2 border-signal pl-5 text-base italic leading-7 text-muted-foreground">
+          {about.subtitle}
+        </blockquote>
+      </header>
+
+      <section className="portfolio-rule border-b py-9">
+        <p className="portfolio-kicker">01 / {copy.profile}</p>
+        <h2 className="mt-3 text-2xl font-semibold">{about.hero.headline}</h2>
+        <p className="mt-5 leading-7 text-muted-foreground">{about.hero.description}</p>
+      </section>
+
+      <section className="portfolio-rule border-b py-9">
+        <p className="portfolio-kicker">02 / {copy.focus}</p>
+        <div className="mt-5 grid gap-6 md:grid-cols-3">
+          {about.focus.items.map((item) => (
+            <div key={item.title}>
+              <h3 className="font-semibold">{item.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="portfolio-rule border-b py-9">
+        <p className="portfolio-kicker">03 / {copy.projects}</p>
+        <div className="mt-5">
+          {orderedProjects.map((project, index) => (
+            <div
+              key={project.slug}
+              className="portfolio-rule grid gap-4 border-t py-6 sm:grid-cols-[52px_1fr]"
+            >
+              <span className="font-mono text-xs text-muted-foreground">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <div>
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <h3 className="text-lg font-semibold">{project.title}</h3>
+                  <span className="font-mono text-xs text-protocol">{project.kind[locale]}</span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  {project.description[locale]}
+                </p>
+                {project.architecture ? (
+                  <p className="mt-3 font-mono text-xs leading-6 text-foreground">
+                    {project.architecture.join(' -> ')}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="portfolio-rule border-b py-9">
+        <p className="portfolio-kicker">04 / {copy.experience}</p>
+        <div className="mt-5 space-y-8">
+          {about.experience.items.map((item) => (
+            <div key={item.role} className="grid gap-2 sm:grid-cols-[180px_1fr]">
+              <p className="font-mono text-xs text-muted-foreground">{item.period}</p>
+              <div>
+                <h3 className="font-semibold">{item.role}</h3>
+                <p className="text-sm text-protocol">{item.organization}</p>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">{item.summary}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="portfolio-rule border-b py-9">
+        <p className="portfolio-kicker">05 / {copy.stack}</p>
+        <dl className="mt-5 grid gap-x-8 gap-y-5 sm:grid-cols-2">
+          {skillGroups.map((skill) => (
+            <div key={skill.title}>
+              <dt className="font-mono text-xs font-medium text-signal">{skill.title}</dt>
+              <dd className="mt-2 text-sm leading-6 text-muted-foreground">{skill.description}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="py-9">
+        <p className="portfolio-kicker">06 / {copy.contact}</p>
+        <div className="mt-5 space-y-2 font-mono text-sm">
+          <p>contact: {SITE_URL + (locale === 'pt-BR' ? '/pt-BR/contact' : '/contact')}</p>
+          <p>github: github.com/mateusribeirocampos</p>
+          <p>linkedin: linkedin.com/in/mateus-ribeiro-de-campos-6a135331</p>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+export function MachineReadablePortfolio({ lang }: { lang: string }) {
+  const pathname = usePathname();
+  const locale: ProjectLocale = lang === 'pt-BR' ? 'pt-BR' : 'en';
+  const copy = uiCopy[locale];
+  const about = locale === 'pt-BR' ? aboutPtBr.about : aboutEn.about;
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<'rendered' | 'source'>('rendered');
+  const [copied, setCopied] = useState(false);
+  const markdown = useMemo(
+    () =>
+      buildPortfolioMarkdown({
+        locale,
+        siteUrl: SITE_URL,
+        about,
+        projects,
+      }),
+    [about, locale],
+  );
+
+  if (pathname.startsWith('/admin')) return null;
+
+  const copyMarkdown = async () => {
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  };
+
+  const machineUrl = '/portfolio.md?lang=' + locale;
+  const downloadUrl = machineUrl + '&download=1';
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="fixed inset-0 left-0 top-0 z-[90] block h-[100dvh] w-screen max-w-none translate-x-0 translate-y-0 overflow-y-auto rounded-none border-0 bg-background p-0 shadow-none duration-200 sm:rounded-none [&>button]:hidden">
+          <DialogTitle className="sr-only">{copy.machine}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {locale === 'pt-BR'
+              ? 'Versão estruturada e legível por máquinas do portfólio.'
+              : 'Structured, machine-readable version of the portfolio.'}
+          </DialogDescription>
+
+          <header className="portfolio-rule sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
+            <div className="mx-auto flex min-h-16 max-w-7xl flex-wrap items-center gap-2 px-[15px] py-2">
+              <span className="flex items-center gap-2 rounded-full border border-signal/40 bg-signal/10 px-3 py-1 font-mono text-[11px] font-medium uppercase text-signal">
+                <span className="h-1.5 w-1.5 rounded-full bg-signal" aria-hidden="true" />
+                {copy.ready}
+              </span>
+              <a
+                href={machineUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="hidden rounded-md border px-3 py-1.5 font-mono text-xs text-protocol hover:bg-accent sm:inline-flex"
+              >
+                /portfolio.md
+              </a>
+
+              <div
+                className="ml-auto flex rounded-md border bg-muted/40 p-1"
+                aria-label={locale === 'pt-BR' ? 'Modo de leitura' : 'Reading mode'}
+              >
+                <button
+                  type="button"
+                  onClick={() => setMode('rendered')}
+                  aria-pressed={mode === 'rendered'}
+                  className={cn(
+                    'rounded px-3 py-1.5 font-mono text-xs transition-colors',
+                    mode === 'rendered' && 'bg-background text-foreground shadow-sm',
+                  )}
+                >
+                  {copy.rendered}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode('source')}
+                  aria-pressed={mode === 'source'}
+                  className={cn(
+                    'rounded px-3 py-1.5 font-mono text-xs transition-colors',
+                    mode === 'source' && 'bg-background text-foreground shadow-sm',
+                  )}
+                >
+                  {copy.source}
+                </button>
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={copyMarkdown}
+                aria-label={copied ? copy.copied : copy.copy}
+                title={copied ? copy.copied : copy.copy}
+              >
+                {copied ? <Check className="h-4 w-4 text-signal" /> : <Copy className="h-4 w-4" />}
+              </Button>
+              <Button variant="outline" size="icon" asChild>
+                <a href={downloadUrl} aria-label={copy.download} title={copy.download}>
+                  <Download className="h-4 w-4" />
+                </a>
+              </Button>
+              <DialogClose asChild>
+                <Button variant="outline" size="icon" aria-label={copy.close} title={copy.close}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </DialogClose>
+            </div>
+          </header>
+
+          {mode === 'rendered' ? (
+            <MachineDocument locale={locale} />
+          ) : (
+            <div className="mx-auto max-w-5xl px-[15px] pb-28 pt-10">
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-card p-5 font-mono text-xs leading-6 text-foreground sm:p-8 sm:text-sm">
+                {markdown}
+              </pre>
+            </div>
+          )}
+
+          <div
+            className="fixed bottom-4 right-4 z-[100] flex items-center rounded-full border bg-background/95 p-1 shadow-lg backdrop-blur"
+            role="group"
+            aria-label={locale === 'pt-BR' ? 'Selecionar visualização' : 'Select view'}
+          >
+            <DialogClose asChild>
+              <button
+                type="button"
+                aria-pressed={false}
+                aria-label={copy.human}
+                title={copy.human}
+                className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <UserRound className="h-4 w-4" />
+              </button>
+            </DialogClose>
+            <button
+              type="button"
+              aria-pressed={true}
+              aria-label={copy.machine}
+              title={copy.machine}
+              className="relative flex h-9 w-9 items-center justify-center rounded-full bg-signal text-black"
+            >
+              <Bot className="h-4 w-4" />
+              <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-black/70" aria-hidden="true" />
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {!open ? (
+        <div
+          className="fixed bottom-4 right-4 z-[100] flex items-center rounded-full border bg-background/95 p-1 shadow-lg backdrop-blur"
+          role="group"
+          aria-label={locale === 'pt-BR' ? 'Selecionar visualização' : 'Select view'}
+        >
+          <button
+            type="button"
+            aria-pressed={true}
+            aria-label={copy.human}
+            title={copy.human}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-foreground text-background"
+          >
+            <UserRound className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            aria-pressed={false}
+            aria-label={copy.machine}
+            title={copy.machine}
+            className="relative flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Bot className="h-4 w-4" />
+            <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-signal" aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/components/matrixRain.tsx
+++ b/frontend/components/matrixRain.tsx
@@ -9,54 +9,70 @@ const MatrixRain = () => {
     const ctx = canvas?.getContext('2d');
     if (!canvas || !ctx) return;
 
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    const glyphs = 'アァカサタナハマヤャラワガザダバパ0123456789{}[]/=><'.split('');
+    const protocolTokens = ['GET', 'POST', 'JWT', '200', '201', 'SQL', 'API'];
+    const fontSize = 13;
+    const columnWidth = 24;
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let drops: number[] = [];
+    let animationFrame = 0;
+    let previousFrame = 0;
 
-    const chars = 'アァカサタナハマヤャラワガザダバパ0123456789'.split('');
-    const fontSize = 16;
-    const columns = canvas.width / fontSize;
-    // Definir o tipo explicitamente para number[]
-    const drops: number[] = Array.from({ length: Math.floor(columns) }, () => 1);
+    const resizeCanvas = () => {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = Math.floor(window.innerWidth * ratio);
+      canvas.height = Math.floor(window.innerHeight * ratio);
+      canvas.style.width = window.innerWidth + 'px';
+      canvas.style.height = window.innerHeight + 'px';
+      ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+
+      const columns = Math.ceil(window.innerWidth / columnWidth);
+      drops = Array.from({ length: columns }, (_, index) => drops[index] ?? Math.random() * -30);
+    };
 
     const draw = () => {
-      // Obtém os valores CSS computados
       const computedStyle = getComputedStyle(document.documentElement);
       const transparentMatrix = computedStyle.getPropertyValue('--transparent-matrix');
       const fillStyle = computedStyle.getPropertyValue('--fillstyle');
-      
-      // Fundo semi-transparente para efeito de rastro
-      ctx.fillStyle = transparentMatrix;
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // Define a cor das letras
+      ctx.fillStyle = transparentMatrix;
+      ctx.fillRect(0, 0, window.innerWidth, window.innerHeight);
+
       ctx.fillStyle = fillStyle;
-      ctx.font = `${fontSize}px monospace`;
+      ctx.font = fontSize + 'px monospace';
 
       drops.forEach((y: number, i: number) => {
-        const text = chars[Math.floor(Math.random() * chars.length)];
-        const x = i * fontSize;
+        const useProtocolToken = Math.random() > 0.965;
+        const source = useProtocolToken ? protocolTokens : glyphs;
+        const text = source[Math.floor(Math.random() * source.length)];
+        const x = i * columnWidth;
         ctx.fillText(text, x, y * fontSize);
 
-        if (y * fontSize > canvas.height && Math.random() > 0.975) {
-          drops[i] = 0;
+        if (y * fontSize > window.innerHeight && Math.random() > 0.975) {
+          drops[i] = Math.random() * -12;
         } else {
           drops[i]++;
         }
       });
     };
 
-    const interval = setInterval(draw, 50);
-
-    const handleResize = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+    const animate = (timestamp: number) => {
+      if (timestamp - previousFrame >= 58) {
+        draw();
+        previousFrame = timestamp;
+      }
+      animationFrame = window.requestAnimationFrame(animate);
     };
 
-    window.addEventListener('resize', handleResize);
+    resizeCanvas();
+    draw();
+    if (!reducedMotion) animationFrame = window.requestAnimationFrame(animate);
+
+    window.addEventListener('resize', resizeCanvas);
 
     return () => {
-      clearInterval(interval);
-      window.removeEventListener('resize', handleResize);
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener('resize', resizeCanvas);
     };
   }, []);
 
@@ -70,7 +86,7 @@ const MatrixRain = () => {
         zIndex: -1,
         width: '100%',
         height: '100%',
-        backgroundColor: 'transparent', // Removido o fundo preto fixo para usar as cores do tema
+        backgroundColor: 'transparent',
       }}
     />
   );

--- a/frontend/data/projects.ts
+++ b/frontend/data/projects.ts
@@ -1,49 +1,176 @@
 export type ProjectLocale = 'en' | 'pt-BR';
+export type LocalizedProjectText = Record<ProjectLocale, string>;
+
+export interface ProjectEvidence {
+  label: LocalizedProjectText;
+  value: LocalizedProjectText;
+}
 
 export interface Project {
+  slug: string;
   title: string;
-  description: Record<ProjectLocale, string>;
+  kind: LocalizedProjectText;
+  status: LocalizedProjectText;
+  description: LocalizedProjectText;
   image: string;
   secondImage?: string;
   tags: string[];
+  architecture?: string[];
+  evidence?: ProjectEvidence[];
+  featured?: boolean;
+  featuredOrder?: number;
   github?: string;
   demo?: string;
 }
 
 export const projects: Project[] = [
   {
+    slug: 'dscommerce',
     title: 'DSCommerce',
+    kind: {
+      en: 'Backend API',
+      'pt-BR': 'API backend',
+    },
+    status: {
+      en: 'Public deployment',
+      'pt-BR': 'Deploy público',
+    },
     description: {
       en: 'E-commerce REST API with products, categories, users, orders, OAuth2/JWT authentication, role-based authorization, JPA/Hibernate persistence, and OpenAPI documentation.',
       'pt-BR': 'API REST de e-commerce com produtos, categorias, usuários, pedidos, autenticação OAuth2/JWT, autorização por perfis, persistência JPA/Hibernate e documentação OpenAPI.',
     },
     image: '/images/projects/dscommerce.png',
-    tags: ['Java 21', 'Spring Boot 3', 'Spring Security', 'OAuth2', 'JWT', 'PostgreSQL', 'Spring Data JPA', 'Maven', 'Docker'],
+    tags: ['Java 21', 'Spring Boot 3', 'Spring Security', 'OAuth2', 'JWT', 'PostgreSQL', 'JPA', 'Docker'],
+    architecture: ['REST API', 'Spring Security', 'Service layer', 'JPA / Hibernate', 'PostgreSQL'],
+    evidence: [
+      {
+        label: { en: 'Security', 'pt-BR': 'Segurança' },
+        value: {
+          en: 'OAuth2/JWT authentication with role-based authorization.',
+          'pt-BR': 'Autenticação OAuth2/JWT com autorização baseada em perfis.',
+        },
+      },
+      {
+        label: { en: 'Domain', 'pt-BR': 'Domínio' },
+        value: {
+          en: 'Products, categories, users and orders modeled as API resources.',
+          'pt-BR': 'Produtos, categorias, usuários e pedidos modelados como recursos da API.',
+        },
+      },
+      {
+        label: { en: 'Delivery', 'pt-BR': 'Entrega' },
+        value: {
+          en: 'OpenAPI documentation, Maven build and containerized deployment.',
+          'pt-BR': 'Documentação OpenAPI, build Maven e deploy em contêiner.',
+        },
+      },
+    ],
+    featured: true,
+    featuredOrder: 2,
     github: 'https://github.com/mateusribeirocampos/project-spring-boot-dscommerce',
     demo: 'https://project-spring-boot-dscommerce.onrender.com',
   },
   {
+    slug: 'cvnoalvo',
     title: 'CVnoAlvo',
+    kind: {
+      en: 'Production product',
+      'pt-BR': 'Produto em produção',
+    },
+    status: {
+      en: 'Live',
+      'pt-BR': 'Online',
+    },
     description: {
       en: 'Web application for adapting resumes to specific job openings, with compatibility analysis, ATS-focused artifact generation, Java/Spring backend, PostgreSQL, and JWT authentication.',
       'pt-BR': 'Aplicação web para adaptar currículos a vagas específicas, com análise de compatibilidade, geração de artefatos otimizados para ATS, backend Java/Spring, PostgreSQL e autenticação JWT.',
     },
     image: '/images/projects/cvnoalvo.jpg',
     tags: ['Java 21', 'Spring Boot', 'Spring Security', 'JWT', 'PostgreSQL', 'Docker', 'Next.js'],
+    architecture: ['Next.js', 'Java 21 API', 'Spring Security', 'PostgreSQL', 'External services'],
+    evidence: [
+      {
+        label: { en: 'Product', 'pt-BR': 'Produto' },
+        value: {
+          en: 'A guided workflow that turns a job opening into ATS-focused resume artifacts.',
+          'pt-BR': 'Fluxo guiado que transforma uma vaga em artefatos de currículo voltados a ATS.',
+        },
+      },
+      {
+        label: { en: 'Backend', 'pt-BR': 'Backend' },
+        value: {
+          en: 'Java/Spring services with JWT security and PostgreSQL persistence.',
+          'pt-BR': 'Serviços Java/Spring com segurança JWT e persistência PostgreSQL.',
+        },
+      },
+      {
+        label: { en: 'Delivery', 'pt-BR': 'Entrega' },
+        value: {
+          en: 'Full-stack product running in production with external integrations.',
+          'pt-BR': 'Produto full stack em produção com integrações externas.',
+        },
+      },
+    ],
+    featured: true,
+    featuredOrder: 1,
     demo: 'https://www.cvnoalvo.com.br',
   },
   {
+    slug: 'sysmp',
     title: 'SYSMP',
+    kind: {
+      en: 'Full-stack system',
+      'pt-BR': 'Sistema full stack',
+    },
+    status: {
+      en: 'Private product',
+      'pt-BR': 'Produto privado',
+    },
     description: {
       en: 'Full-stack deadline management system with JWT authentication, an admin dashboard, PostgreSQL, and real-time communication for operational follow-up.',
       'pt-BR': 'Sistema full-stack para gestão de prazos com autenticação JWT, painel administrativo, PostgreSQL e comunicação em tempo real para acompanhamento operacional.',
     },
     image: '/images/projects/sysmp.jpg',
     tags: ['Node.js', 'Express', 'React', 'TypeScript', 'WebSocket', 'PostgreSQL', 'JWT'],
+    architecture: ['React', 'Express API', 'JWT', 'WebSocket', 'PostgreSQL'],
+    evidence: [
+      {
+        label: { en: 'Operations', 'pt-BR': 'Operação' },
+        value: {
+          en: 'Administrative workflows for users, documents and deadlines.',
+          'pt-BR': 'Fluxos administrativos para usuários, documentos e prazos.',
+        },
+      },
+      {
+        label: { en: 'Real time', 'pt-BR': 'Tempo real' },
+        value: {
+          en: 'WebSocket communication for operational status updates.',
+          'pt-BR': 'Comunicação WebSocket para atualização de status operacionais.',
+        },
+      },
+      {
+        label: { en: 'Security', 'pt-BR': 'Segurança' },
+        value: {
+          en: 'JWT authentication protecting administrative access.',
+          'pt-BR': 'Autenticação JWT protegendo o acesso administrativo.',
+        },
+      },
+    ],
+    featured: true,
+    featuredOrder: 3,
     github: 'https://github.com/mateusribeirocampos',
   },
   {
+    slug: 'dragenda',
     title: 'Dragenda',
+    kind: {
+      en: 'Scheduling application',
+      'pt-BR': 'Aplicação de agendamento',
+    },
+    status: {
+      en: 'Public demo',
+      'pt-BR': 'Demo pública',
+    },
     description: {
       en: 'Healthcare scheduling application with a React frontend, Node.js/Express backend, SQLite persistence, and separate frontend/backend deployments on Vercel and Render.',
       'pt-BR': 'Aplicação de agendamento em saúde com frontend React, backend Node.js/Express, persistência SQLite e deploy separado entre Vercel e Render.',
@@ -55,7 +182,16 @@ export const projects: Project[] = [
     demo: 'https://dragenda.vercel.app',
   },
   {
+    slug: 'santa-rita',
     title: 'Website - Santa Rita church',
+    kind: {
+      en: 'Institutional website',
+      'pt-BR': 'Site institucional',
+    },
+    status: {
+      en: 'Live',
+      'pt-BR': 'Online',
+    },
     description: {
       en: 'Responsive institutional website for Santa Rita Church, built with React, TypeScript, Vite, and Tailwind CSS for clear content organization and mobile access.',
       'pt-BR': 'Site institucional responsivo para a Igreja Santa Rita, construído com React, TypeScript, Vite e Tailwind CSS para organizar informações e facilitar o acesso mobile.',
@@ -67,7 +203,16 @@ export const projects: Project[] = [
     demo: 'https://igrejasantaritaourofino.vercel.app/',
   },
   {
+    slug: 'dio-machine-learning',
     title: 'DIO - Machine Learning',
+    kind: {
+      en: 'Applied studies',
+      'pt-BR': 'Estudos aplicados',
+    },
+    status: {
+      en: 'Study repository',
+      'pt-BR': 'Repositório de estudos',
+    },
     description: {
       en: 'Study repository from the DIO Machine Learning Practitioner Bootcamp, with Python notebooks for facial recognition, image recommendation, and virtual assistant experiments.',
       'pt-BR': 'Repositório de estudos do bootcamp DIO Machine Learning Practitioner, com notebooks em Python para reconhecimento facial, recomendação por imagens e experimentos com assistentes virtuais.',

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,26 +1,22 @@
-import { defineConfig, globalIgnores } from 'eslint/config';
-import nextVitals from 'eslint-config-next/core-web-vitals';
-import nextTs from 'eslint-config-next/typescript';
+import { FlatCompat } from '@eslint/eslintrc';
+import { fileURLToPath } from 'node:url';
 
-const eslintConfig = defineConfig([
-  ...nextVitals,
-  ...nextTs,
+const baseDirectory = fileURLToPath(new URL('.', import.meta.url));
+const compat = new FlatCompat({ baseDirectory });
+
+const eslintConfig = [
+  {
+    ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
+  },
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
     rules: {
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
-      'react-hooks/immutability': 'off',
-      'react-hooks/set-state-in-effect': 'off',
     },
   },
-  globalIgnores([
-    '.next/**',
-    'out/**',
-    'build/**',
-    'next-env.d.ts',
-  ]),
-]);
+];
 
 export default eslintConfig;

--- a/frontend/lib/portfolio-machine-content.js
+++ b/frontend/lib/portfolio-machine-content.js
@@ -1,0 +1,214 @@
+const labels = {
+  en: {
+    role: 'Backend Developer',
+    language: 'English',
+    profile: 'Profile',
+    focus: 'How I work',
+    stack: 'Core capabilities',
+    experience: 'Experience',
+    featuredProjects: 'Featured projects',
+    otherProjects: 'Additional projects',
+    education: 'Education',
+    contact: 'Contact',
+    type: 'Type',
+    status: 'Status',
+    architecture: 'Architecture',
+    evidence: 'Engineering evidence',
+    technologies: 'Technologies',
+    source: 'Source code',
+    demo: 'Live product',
+    period: 'Period',
+    organization: 'Organization',
+  },
+  'pt-BR': {
+    role: 'Desenvolvedor Backend',
+    language: 'Português do Brasil',
+    profile: 'Perfil',
+    focus: 'Como atuo',
+    stack: 'Competências principais',
+    experience: 'Experiência',
+    featuredProjects: 'Projetos em destaque',
+    otherProjects: 'Projetos complementares',
+    education: 'Formação',
+    contact: 'Contato',
+    type: 'Tipo',
+    status: 'Status',
+    architecture: 'Arquitetura',
+    evidence: 'Evidências técnicas',
+    technologies: 'Tecnologias',
+    source: 'Código-fonte',
+    demo: 'Produto online',
+    period: 'Período',
+    organization: 'Organização',
+  },
+};
+
+const contact = {
+  github: 'https://github.com/mateusribeirocampos',
+  linkedin: 'https://www.linkedin.com/in/mateus-ribeiro-de-campos-6a135331/',
+};
+
+function resolveLabels(locale) {
+  return labels[locale === 'pt-BR' ? 'pt-BR' : 'en'];
+}
+
+function markdownList(items) {
+  return items.map((item) => '- ' + item).join('\n');
+}
+
+function projectMarkdown(project, locale, copy) {
+  const lines = [
+    '### ' + project.title,
+    '',
+    project.description[locale],
+    '',
+    '- **' + copy.type + ':** ' + project.kind[locale],
+    '- **' + copy.status + ':** ' + project.status[locale],
+  ];
+
+  if (project.architecture?.length) {
+    lines.push('- **' + copy.architecture + ':** ' + project.architecture.join(' -> '));
+  }
+
+  lines.push('- **' + copy.technologies + ':** ' + project.tags.join(', '));
+
+  if (project.evidence?.length) {
+    lines.push('', '**' + copy.evidence + '**', '');
+    lines.push(
+      markdownList(
+        project.evidence.map(
+          (item) => '**' + item.label[locale] + ':** ' + item.value[locale],
+        ),
+      ),
+    );
+  }
+
+  if (project.github) {
+    lines.push('', '- [' + copy.source + '](' + project.github + ')');
+  }
+
+  if (project.demo) {
+    lines.push('- [' + copy.demo + '](' + project.demo + ')');
+  }
+
+  return lines.join('\n');
+}
+
+export function buildPortfolioMarkdown({
+  locale = 'en',
+  siteUrl,
+  about,
+  projects,
+}) {
+  const resolvedLocale = locale === 'pt-BR' ? 'pt-BR' : 'en';
+  const copy = resolveLabels(resolvedLocale);
+  const featured = projects
+    .filter((project) => project.featured)
+    .sort((a, b) => (a.featuredOrder ?? 0) - (b.featuredOrder ?? 0));
+  const additional = projects.filter((project) => !project.featured);
+  const skillGroups = Object.values(about.skills).filter(
+    (value) => value && typeof value === 'object' && 'title' in value,
+  );
+  const education = [
+    about.education.computerScience,
+    about.education.doctorate,
+    about.education.masters,
+    about.education.agronomy,
+  ];
+
+  return [
+    '# Mateus R. Campos — ' + copy.role,
+    '',
+    '> ' + about.subtitle,
+    '',
+    '- **Canonical:** ' + siteUrl,
+    '- **Language:** ' + copy.language + ' (' + resolvedLocale + ')',
+    '- **Machine-readable source:** ' + siteUrl + '/portfolio.md?lang=' + resolvedLocale,
+    '',
+    '## ' + copy.profile,
+    '',
+    about.hero.description,
+    '',
+    '## ' + copy.focus,
+    '',
+    about.focus.items
+      .map((item) => '### ' + item.title + '\n\n' + item.description)
+      .join('\n\n'),
+    '',
+    '## ' + copy.stack,
+    '',
+    markdownList(
+      skillGroups.map((skill) => '**' + skill.title + ':** ' + skill.description),
+    ),
+    '',
+    '## ' + copy.experience,
+    '',
+    about.experience.items
+      .map((item) =>
+        [
+          '### ' + item.role,
+          '',
+          '- **' + copy.organization + ':** ' + item.organization,
+          '- **' + copy.period + ':** ' + item.period,
+          '',
+          item.summary,
+          '',
+          markdownList(item.bullets),
+        ].join('\n'),
+      )
+      .join('\n\n'),
+    '',
+    '## ' + copy.featuredProjects,
+    '',
+    featured.map((project) => projectMarkdown(project, resolvedLocale, copy)).join('\n\n'),
+    '',
+    '## ' + copy.otherProjects,
+    '',
+    additional.map((project) => projectMarkdown(project, resolvedLocale, copy)).join('\n\n'),
+    '',
+    '## ' + copy.education,
+    '',
+    markdownList(
+      education.map((item) => '**' + item.title + ':** ' + item.description),
+    ),
+    '',
+    '## ' + copy.contact,
+    '',
+    '- **Contact form:** ' + siteUrl + (resolvedLocale === 'pt-BR' ? '/pt-BR/contact' : '/contact'),
+    '- **GitHub:** ' + contact.github,
+    '- **LinkedIn:** ' + contact.linkedin,
+    '- **Website:** ' + siteUrl,
+    '',
+  ].join('\n');
+}
+
+export function buildLlmsText({ locale = 'en', siteUrl, about }) {
+  const resolvedLocale = locale === 'pt-BR' ? 'pt-BR' : 'en';
+  const copy = resolveLabels(resolvedLocale);
+  const prefix = resolvedLocale === 'pt-BR' ? '/pt-BR' : '';
+
+  return [
+    '# Mateus R. Campos — ' + copy.role,
+    '',
+    '> ' + about.subtitle,
+    '',
+    '## Machine-readable portfolio',
+    '',
+    '- [Full portfolio in Markdown](' + siteUrl + '/portfolio.md?lang=' + resolvedLocale + ')',
+    '',
+    '## Human-readable pages',
+    '',
+    '- [Home](' + siteUrl + prefix + ')',
+    '- [Projects](' + siteUrl + prefix + '/projects)',
+    '- [About](' + siteUrl + prefix + '/about)',
+    '- [Blog](' + siteUrl + prefix + '/blog)',
+    '- [Contact](' + siteUrl + prefix + '/contact)',
+    '',
+    '## Contact',
+    '',
+    '- Contact form: ' + siteUrl + prefix + '/contact',
+    '- GitHub: ' + contact.github,
+    '- LinkedIn: ' + contact.linkedin,
+    '',
+  ].join('\n');
+}

--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -1,16 +1,57 @@
 {
   "home": {
-    "title": "Hi, I'm Mateus R Campos",
-    "pTitle": "Backend Developer (Java, Spring Boot) | BSc in Computer Science | Node.js",
-    "contact_button": "Get in Touch",
-    "projects_button": "View Projects",
-    "subtitle": "Skills & Expertise",
-    "pSubtitle": "Java Developer focused on backend development with Spring Boot 3.5 and RESTful API architecture. Bachelor's in Computer Science combined with a background in international scientific research, bringing an analytical and methodical approach to software engineering.",
-    "TitleCard1": "Backend Java",
-    "pCard1": "Spring Boot 3.5, Spring Security, JPA, Hibernate, REST APIs",
-    "TitleCard2": "Frontend Web",
-    "pCard2": "React, TypeScript, Next.js, Tailwind CSS, Vite",
-    "TitleCard3": "Scientific Research",
-    "pCard3": "PhD in Entomology with statistical analysis, biological modeling, and scientific methodology applied to development."
+    "eyebrow": "Mateus R. Campos / Backend Developer",
+    "availability": "Available for backend opportunities",
+    "title": "Secure APIs and backend systems built to evolve.",
+    "description": "I build REST services with Java, Spring Boot, and Node.js, covering authentication, persistence, automated testing, and documentation. When the product calls for it, I also deliver the interface with React and Next.js.",
+    "projects_button": "View projects",
+    "contact_button": "Get in touch",
+    "github_button": "View GitHub",
+    "stack_label": "Core stack",
+    "stack": "Java 21 · Spring Boot · Node.js · PostgreSQL",
+    "trace": {
+      "request": "Request",
+      "request_value": "POST /api/resource",
+      "security": "Security",
+      "security_value": "JWT + roles",
+      "persistence": "Persistence",
+      "persistence_value": "PostgreSQL",
+      "response": "Response",
+      "response_value": "201 Created"
+    },
+    "evidence": {
+      "eyebrow": "Work you can inspect",
+      "title": "Backend demonstrated through products, not technology lists.",
+      "description": "Three projects showing security, data modeling, integrations, and operations in different contexts.",
+      "project_link": "View technical details"
+    },
+    "process": {
+      "eyebrow": "How I build",
+      "title": "From API contract to deployment.",
+      "description": "A delivery sequence grounded in behavior, security, and maintainability.",
+      "steps": {
+        "contract": {
+          "title": "Contract and domain",
+          "description": "I define resources, responsibilities, responses, and rules before coupling the implementation."
+        },
+        "security": {
+          "title": "Security and data",
+          "description": "Authentication, authorization, validation, and persistence are treated as part of the design."
+        },
+        "quality": {
+          "title": "Verifiable quality",
+          "description": "Automated tests and documentation protect critical flows and make change easier."
+        },
+        "delivery": {
+          "title": "Delivery and operations",
+          "description": "Containers, environment configuration, and actionable error reporting close the loop."
+        }
+      }
+    },
+    "closing": {
+      "eyebrow": "Next challenge",
+      "title": "I look for problems that deserve a clear, secure, and sustainable backend.",
+      "description": "I am open to backend and full-stack opportunities in teams that value technical quality, collaboration, and continuous learning."
+    }
   }
 }

--- a/frontend/public/locales/en/projects.json
+++ b/frontend/public/locales/en/projects.json
@@ -1,7 +1,16 @@
 {
   "projects": {
-    "title": "Projects",
-    "pTitle": "A collection of my technical projects, with a focus on Java Spring Boot backend development, REST APIs, and full-stack applications.",
-    "liveDemo": "Live Demo"
+    "eyebrow": "Projects / Applied engineering",
+    "title": "Systems built from the inside out.",
+    "pTitle": "A selection of APIs and full-stack products presented through their architecture, security, data, and delivery decisions.",
+    "featuredTitle": "Featured projects",
+    "featuredDescription": "Three different contexts with the backend at the center of the solution.",
+    "architectureLabel": "Solution flow",
+    "evidenceLabel": "Engineering evidence",
+    "stackLabel": "Technologies",
+    "otherTitle": "Other work",
+    "otherDescription": "Web, mobile, and study projects that complement my full-stack practice.",
+    "sourceCode": "Source",
+    "liveDemo": "Live demo"
   }
 }

--- a/frontend/public/locales/pt-BR/home.json
+++ b/frontend/public/locales/pt-BR/home.json
@@ -1,16 +1,57 @@
 {
   "home": {
-    "title": "Olá, eu sou Mateus R Campos",
-    "pTitle": "Desenvolvedor Backend (Java, Spring Boot) | Bacharel em Ciência da Computação | Node.js",
-    "contact_button": "Entrar em Contato",
-    "projects_button": "Ver Projetos",
-    "subtitle": "Habilidades e Especialidades",
-    "pSubtitle": "Desenvolvedor Java com foco em backend, especializado em Spring Boot 3.5 e arquitetura de APIs RESTful. Bacharel em Ciência da Computação com background em pesquisa científica internacional, trazendo uma abordagem analítica e metodológica para engenharia de software.",
-    "TitleCard1": "Backend Java",
-    "pCard1": "Spring Boot 3.5, Spring Security, JPA, Hibernate, REST APIs",
-    "TitleCard2": "Frontend Web",
-    "pCard2": "React, TypeScript, Next.js, Tailwind CSS, Vite",
-    "TitleCard3": "Pesquisa Científica",
-    "pCard3": "PhD em Entomologia com análise estatística, modelagem biológica e metodologia científica aplicada ao desenvolvimento."
+    "eyebrow": "Mateus R. Campos / Backend Developer",
+    "availability": "Disponível para oportunidades backend",
+    "title": "APIs seguras e sistemas backend feitos para evoluir.",
+    "description": "Desenvolvo serviços REST com Java, Spring Boot e Node.js, cobrindo autenticação, persistência, testes automatizados e documentação. Quando o produto exige, entrego também a interface em React e Next.js.",
+    "projects_button": "Ver projetos",
+    "contact_button": "Entrar em contato",
+    "github_button": "Ver GitHub",
+    "stack_label": "Stack principal",
+    "stack": "Java 21 · Spring Boot · Node.js · PostgreSQL",
+    "trace": {
+      "request": "Requisição",
+      "request_value": "POST /api/resource",
+      "security": "Segurança",
+      "security_value": "JWT + perfis",
+      "persistence": "Persistência",
+      "persistence_value": "PostgreSQL",
+      "response": "Resposta",
+      "response_value": "201 Created"
+    },
+    "evidence": {
+      "eyebrow": "Trabalho comprovável",
+      "title": "Backend demonstrado em produtos, não apenas em listas de tecnologias.",
+      "description": "Três projetos que mostram segurança, modelagem de dados, integrações e operação em contextos diferentes.",
+      "project_link": "Ver detalhes técnicos"
+    },
+    "process": {
+      "eyebrow": "Como construo",
+      "title": "Do contrato da API ao deploy.",
+      "description": "Uma sequência de trabalho orientada a comportamento, segurança e manutenção.",
+      "steps": {
+        "contract": {
+          "title": "Contrato e domínio",
+          "description": "Defino recursos, responsabilidades, respostas e regras antes de acoplar a implementação."
+        },
+        "security": {
+          "title": "Segurança e dados",
+          "description": "Trato autenticação, autorização, validação e persistência como partes do desenho."
+        },
+        "quality": {
+          "title": "Qualidade verificável",
+          "description": "Testes automatizados e documentação protegem os fluxos críticos e facilitam evolução."
+        },
+        "delivery": {
+          "title": "Entrega e operação",
+          "description": "Containerização, configuração por ambiente e observação dos erros fecham o ciclo."
+        }
+      }
+    },
+    "closing": {
+      "eyebrow": "Próximo desafio",
+      "title": "Procuro problemas que mereçam um backend claro, seguro e sustentável.",
+      "description": "Estou aberto a oportunidades backend e full stack em equipes que valorizem qualidade técnica, colaboração e aprendizado contínuo."
+    }
   }
 }

--- a/frontend/public/locales/pt-BR/projects.json
+++ b/frontend/public/locales/pt-BR/projects.json
@@ -1,7 +1,16 @@
 {
   "projects": {
-    "title": "Projetos",
-    "pTitle": "Uma coleção de projetos técnicos com foco em desenvolvimento backend Java Spring Boot, APIs REST e aplicações full-stack.",
+    "eyebrow": "Projetos / Engenharia aplicada",
+    "title": "Sistemas construídos de dentro para fora.",
+    "pTitle": "Uma seleção de APIs e produtos full stack apresentada pelas decisões de arquitetura, segurança, dados e entrega.",
+    "featuredTitle": "Projetos em destaque",
+    "featuredDescription": "Três contextos diferentes, com o backend ocupando o centro da solução.",
+    "architectureLabel": "Fluxo da solução",
+    "evidenceLabel": "Evidências técnicas",
+    "stackLabel": "Tecnologias",
+    "otherTitle": "Outros trabalhos",
+    "otherDescription": "Aplicações web, mobile e estudos que complementam minha atuação full stack.",
+    "sourceCode": "Código",
     "liveDemo": "Demonstração"
   }
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,6 +9,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-plex-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-plex-mono)', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':
@@ -53,6 +57,9 @@ const config: Config = {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
+        signal: 'hsl(var(--signal))',
+        protocol: 'hsl(var(--protocol))',
+        steel: 'hsl(var(--steel))',
         chart: {
           '1': 'hsl(var(--chart-1))',
           '2': 'hsl(var(--chart-2))',

--- a/frontend/test/portfolio-copy-contract.test.mjs
+++ b/frontend/test/portfolio-copy-contract.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  buildLlmsText,
+  buildPortfolioMarkdown,
+} from '../lib/portfolio-machine-content.js';
+
+const localeRoot = new URL('../public/locales/', import.meta.url);
+
+async function readLocalePage(locale, page) {
+  const source = await readFile(new URL(locale + '/' + page + '.json', localeRoot), 'utf8');
+  return JSON.parse(source);
+}
+
+function getShape(value) {
+  if (Array.isArray(value)) {
+    return value.map(getShape);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, getShape(child)]),
+    );
+  }
+
+  return typeof value;
+}
+
+test('home copy exposes the same contract in English and Portuguese', async () => {
+  const [english, portuguese] = await Promise.all([
+    readLocalePage('en', 'home'),
+    readLocalePage('pt-BR', 'home'),
+  ]);
+
+  assert.deepEqual(getShape(english.home), getShape(portuguese.home));
+  assert.match(english.home.title, /backend/i);
+  assert.match(portuguese.home.title, /backend/i);
+});
+
+test('projects copy exposes the same contract in English and Portuguese', async () => {
+  const [english, portuguese] = await Promise.all([
+    readLocalePage('en', 'projects'),
+    readLocalePage('pt-BR', 'projects'),
+  ]);
+
+  assert.deepEqual(getShape(english.projects), getShape(portuguese.projects));
+  assert.equal(typeof english.projects.architectureLabel, 'string');
+  assert.equal(typeof portuguese.projects.evidenceLabel, 'string');
+});
+
+test('machine-readable portfolio excludes direct contact and credential-shaped data', async () => {
+  const about = (await readLocalePage('pt-BR', 'about')).about;
+  const project = {
+    slug: 'example',
+    title: 'Example API',
+    kind: { en: 'Backend API', 'pt-BR': 'API backend' },
+    status: { en: 'Public', 'pt-BR': 'Público' },
+    description: {
+      en: 'An API example.',
+      'pt-BR': 'Um exemplo de API.',
+    },
+    tags: ['Java', 'Spring Boot'],
+    architecture: ['REST API', 'Service', 'PostgreSQL'],
+    evidence: [],
+    featured: true,
+    featuredOrder: 1,
+  };
+  const options = {
+    locale: 'pt-BR',
+    siteUrl: 'https://portfolio.example',
+    about,
+    projects: [project],
+  };
+  const portfolio = buildPortfolioMarkdown(options);
+  const llms = buildLlmsText(options);
+  const machineContent = portfolio + '\n' + llms;
+
+  assert.doesNotMatch(machineContent, /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/);
+  assert.doesNotMatch(
+    machineContent,
+    /(JWT_SECRET|DATABASE_URL|ADMIN_PASSWORD|ALLOW_USER_ADMIN)/i,
+  );
+  assert.match(machineContent, /https:\/\/portfolio\.example\/pt-BR\/contact/);
+  assert.match(portfolio, /REST API -> Service -> PostgreSQL/);
+});


### PR DESCRIPTION
## What changed

- reframes the home page around backend engineering, API delivery, security, data, tests, and operations
- expands featured projects with architecture flows and concrete engineering evidence
- aligns About, Blog, Contact, and Projects with consistent centered spacing
- introduces IBM Plex Sans/Mono and refines Matrix Rain as lightweight protocol telemetry
- adds an accessible Human/LLM view switcher
- publishes `/portfolio.md` and `/llms.txt` as machine-readable resources in English and Brazilian Portuguese
- updates the ESLint flat configuration for the current Next.js 15 setup

## Why

The previous presentation emphasized technology lists and generic cards. This concept makes backend work easier for recruiters and engineers to evaluate by showing responsibilities, architecture, security, persistence, and delivery decisions.

The machine-readable view makes the same public portfolio information directly consumable by crawlers and LLM tools without requiring client-side JavaScript.

## Privacy

Machine-readable output is generated only from public portfolio content. It excludes direct email addresses, phone numbers, environment variables, credentials, admin data, and contact submissions. Contact is routed through the public contact page and professional profiles.

## Validation

- `npm test`: 19 tests passed
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed
- verified `/portfolio.md?lang=pt-BR` returns `text/markdown`
- verified `/llms.txt?lang=pt-BR` returns `text/plain`

The build still reports the repository's existing Next 15.5.11 / SWC 15.5.7 version warning.